### PR TITLE
Release 2.4.0: expose pygame sprite spatial queries

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   # 0) Python linter and formatter: Ruff
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.9
+    rev: v0.15.15
     hooks:
       # Lint + autofix. If Ruff fixes something, the hook exits nonzero to force a re-run.
       - id: ruff

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,7 +44,7 @@ dependencies = [
 
 [[package]]
 name = "fastquadtree"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "num-traits",
  "numpy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fastquadtree"
-version = "2.3.0"
+version = "2.4.0"
 edition = "2021"
 rust-version = "1.89"
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ See the [benchmark section](https://elan456.github.io/fastquadtree/benchmark/) f
 
 * `bounds` — tuple `(min_x, min_y, max_x, max_y)` defines the 2D area covered by the quadtree
 * `capacity` — max number of points kept in a leaf before splitting
-* `max_depth` — optional depth cap. If omitted, the tree can keep splitting as needed
+* `max_depth` — optional depth cap. If omitted, uses the [engine default](https://elan456.github.io/fastquadtree/engine_defaults/#max-depth)
 * `dtype` — data type for coordinates, e.g., `"f32"`, `"f64"`, `"i32"`, `"i64"`
 
 ### Key Methods

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Rust-optimized quadtree with a clean Python API
 - Support for [inserting bounding boxes](https://elan456.github.io/fastquadtree/api/rect_quadtree/) or points
 - Fast KNN and range queries
 - Optional object tracking for id ↔ object mapping
-- Mostly drop-in [pygame sprite-group integration](https://elan456.github.io/fastquadtree/api/pygame/) that adds automatic broadphase culling for faster collision detection (depending on workload)
+- Mostly drop-in [pygame sprite-group integration](https://elan456.github.io/fastquadtree/api/pygame/) that adds automatic broadphase culling plus rect queries and k-NN over sprite rects
 - Fast [serialization](https://elan456.github.io/fastquadtree/benchmark/#serialization-vs-rebuild) to/from bytes
 - Support for multiple data types (f32, f64, i32, i64) for coordinates
 - [100% test coverage](https://codecov.io/gh/Elan456/fastquadtree) and CI on GitHub Actions
@@ -59,7 +59,7 @@ from fastquadtree.pyqtree import Index  # Drop-in pyqtree shim (~10x faster whil
 | `QuadTreeObjects` | Points | Yes | Point indexing with attached Python objects. |
 | `RectQuadTreeObjects` | Bounding boxes | Yes | Rectangle indexing with attached objects. |
 | `fastquadtree.pyqtree.Index` | Bounding boxes | Yes | pyqtree-compatible API, much faster. |
-| `fastquadtree.pygame.Group` | pygame sprites | Yes | Mostly drop-in replacement for `pygame.sprite.Group` with quadtree indexing for faster collision detection. |
+| `fastquadtree.pygame.Group` | pygame sprites | Yes | Mostly drop-in `Group` with sprite queries. |
 
 
 ## Quickstart

--- a/benchmarks/benchmark_np_vs_list.py
+++ b/benchmarks/benchmark_np_vs_list.py
@@ -38,9 +38,9 @@ def _build_tree_np(points_np: np.ndarray) -> float:
     # Direct NumPy path
     inserted = qt.insert_many_np(points_np)
     dt = now() - t0
-    assert (
-        inserted.count == points_np.shape[0]
-    ), f"Inserted {inserted} != {points_np.shape[0]}"
+    assert inserted.count == points_np.shape[0], (
+        f"Inserted {inserted} != {points_np.shape[0]}"
+    )
     return dt
 
 
@@ -49,9 +49,9 @@ def _build_tree_list(points_list: list[tuple[float, float]]) -> float:
     qt = ShimQuadTree(BOUNDS, CAPACITY, max_depth=MAX_DEPTH)
     inserted = qt.insert_many(points_list)
     dt = now() - t0
-    assert inserted.count == len(
-        points_list
-    ), f"Inserted {inserted} != {len(points_list)}"
+    assert inserted.count == len(points_list), (
+        f"Inserted {inserted} != {len(points_list)}"
+    )
     return dt
 
 

--- a/docs/api/pygame.md
+++ b/docs/api/pygame.md
@@ -1,27 +1,8 @@
 # fastquadtree.pygame
 
-`fastquadtree.pygame` is an optional pygame integration for games and
-simulations with many sprite `rect`s. It provides:
-
-- `Group`, a mostly drop-in replacement for `pygame.sprite.Group`
-- `spritecollide(...)`, `spritecollideany(...)`, and `groupcollide(...)`
-  helpers shaped like pygame's collision APIs
-- `Group.query_rect(...)` for viewport culling or broadphase rectangle queries
-  without creating a temporary sprite
-
-The group keeps a `RectQuadTreeObjects` index of each sprite's `rect`. Collision
-helpers use that index as a broadphase, so queries can skip most sprites before
-running the final pygame rectangle collision check.
-
 !!! note "Optional dependency"
     Core `fastquadtree` APIs do not require pygame. This page documents the
     optional `fastquadtree.pygame` integration, which requires pygame or a
     compatible package such as `pygame-ce` when imported at runtime.
-
-```bash
-pip install fastquadtree pygame-ce
-```
-
-## API Reference
 
 ::: fastquadtree.pygame

--- a/docs/engine_defaults.md
+++ b/docs/engine_defaults.md
@@ -1,0 +1,73 @@
+# Engine Defaults
+
+## max_depth {#max-depth}
+
+When `max_depth=None`, the native Python APIs use a dtype-specific engine
+default. These defaults apply to `QuadTree`, `RectQuadTree`,
+`QuadTreeObjects`, `RectQuadTreeObjects`, and the `fastquadtree.pygame`
+integration when `max_depth` is omitted.
+
+| dtype | Engine default `max_depth` |
+|---|---:|
+| `f32` | 24 |
+| `f64` | 53 |
+| `i32` | 32 |
+| `i64` | 64 |
+
+Use `get_inner_max_depth()` on a constructed tree to inspect the resolved
+engine value.
+
+### Why These Values?
+
+Infinite subdivision was the default behavior prior to version 1.4.3. With
+infinite subdivision, inserting two points at the same location could keep
+splitting forever and eventually exhaust memory, as seen in
+[issue #10](https://github.com/Elan456/fastquadtree/issues/10). The engine
+default now caps subdivision before it can become unbounded.
+
+One alternative would be for the engine to check for duplicate coordinates
+before splitting. However, doing so would add work to each insert and make
+splitting behavior harder to define for cells that contain a mixture of
+duplicate and nearby non-duplicate points. Letting duplicated points create a
+depth of 24 or 53 in some parts of the tree can also hurt traversal time, so the
+default is a compromise rather than a perfect answer for every workload.
+
+The default caps are based on a practical starting point for each dtype. Each
+quadtree level halves a node's width and height:
+
+```text
+cell_width_at_depth_d  = world_width / 2^d
+cell_height_at_depth_d = world_height / 2^d
+```
+
+The chosen defaults are roughly aligned with the binary precision available for
+each coordinate type:
+
+- `f32` uses 24 because single-precision floats have about 24 bits of
+  significand precision.
+- `f64` uses 53 because double-precision floats have about 53 bits of
+  significand precision.
+- `i32` uses 32 and `i64` uses 64 because integer coordinates cannot provide
+  more distinct binary subdivision steps than their bit width.
+
+These values are safety defaults, not hard limits on useful subdivision. World
+size and data distribution still matter. For example, with `f32` and a world
+width of `1_000_000_000`, depth 24 still leaves cells about 60 units wide:
+
+```text
+1_000_000_000 / 2^24 ~= 59.6
+```
+
+If most of your points are clustered near the origin and you need to separate
+features smaller than that, more than 24 splits can still be meaningful. In that
+case, pass an explicit `max_depth` larger than the engine default.
+
+For `i32` and `i64`, there is generally no situation where you would need more
+than 32 and 64 subdivisions, respectively.
+
+The defaults are intended to be a relatively safe starting point. Use tighter
+world bounds, coordinate normalization, or an explicit `max_depth` when your
+world is very large compared with the area where points actually cluster.
+
+For best performance, choose a `max_depth` that keeps leaf cells near the scale
+of your typical queries and data spacing.

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@
 - Support for [inserting bounding boxes](api/rect_quadtree.md) or points
 - Fast KNN and range queries
 - Optional object tracking for id ↔ object mapping
-- Mostly drop-in [pygame sprite-group integration](api/pygame.md) that adds automatic broadphase culling for faster collision detection (depending on workload)
+- Mostly drop-in [pygame sprite-group integration](api/pygame.md) that adds automatic broadphase culling plus rect queries and k-NN over sprite rects
 - Fast [serialization](benchmark.md#serialization-vs-rebuild) to/from bytes
 - Support for multiple data types (f32, f64, i32, i64) for coordinates
 - [100% test coverage](https://codecov.io/gh/Elan456/fastquadtree) and CI on GitHub Actions
@@ -63,5 +63,5 @@ from fastquadtree import RectQuadTree  # Bounding box handling
 from fastquadtree import QuadTreeObjects  # Point handling with object tracking
 from fastquadtree import RectQuadTreeObjects  # Bounding box handling with object tracking
 from fastquadtree.pyqtree import Index # Drop-in replacement for pyqtree (~10x faster while keeping the same API)
-from fastquadtree.pygame import Group # Mostly drop-in replacement for pygame.sprite.Group with quadtree indexing (pygame install required)
+from fastquadtree.pygame import Group # Mostly drop-in pygame Group with quadtree queries (pygame install required)
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -103,15 +103,16 @@ Tip: Use `QuadTree` instead of `QuadTreeObjects` for max speed when you do not n
 
 ---
 
-## Pygame sprite groups
+## Pygame sprite groups and spatial queries
 
-The optional `fastquadtree.pygame` module provides a mostly drop-in
-`pygame.sprite.Group` replacement plus collision helpers shaped like pygame's
-own `spritecollide(...)` APIs. It indexes sprite `rect` bounds to give you
-automatic broadphase culling for collision queries and viewport culling.
+The optional `fastquadtree.pygame` module provides a pygame sprite group backed
+by `RectQuadTreeObjects`. It supports normal sprite-group operations, collision
+helpers shaped like pygame's own `spritecollide(...)` APIs, and direct spatial
+queries such as rectangle queries and k-nearest-neighbor search over sprite
+`rect` bounds.
 
 This is most useful when you have many static or mostly stable sprites and each
-query touches only a small part of the world. The tradeoff is tree maintenance:
+query touches only a small part of the world. The tradeoff is index maintenance:
 moving indexed sprites need `Group.update(...)` or `Group.sync(...)` so the
 index reflects their current rects. If most sprites move every frame, create the
 group with `rebuild_on_update=True` to rebuild the index after each
@@ -124,6 +125,7 @@ import fastquadtree.pygame as fpygame
 world_bounds = (0, 0, 2000, 2000)
 blocks = fpygame.Group(bounds=world_bounds)
 blocks.add(block_sprites)
+enemy_id = blocks.insert(enemy_sprite)  # Add one sprite and get its current index ID.
 
 # Collision helper with the same shape as pygame.sprite.spritecollide.
 hits = fpygame.spritecollide(player, blocks, dokill=False)
@@ -132,7 +134,16 @@ hits = fpygame.spritecollide(player, blocks, dokill=False)
 visible = blocks.query_rect(camera_rect, sync=False)
 for sprite in visible:
     screen.blit(sprite.image, sprite.rect.move(-camera_x, -camera_y))
+
+# Direct spatial queries return RectItem objects with item.obj set to the sprite.
+nearest = blocks.nearest_neighbors(player.rect.center, k=5)
+for item in nearest:
+    print(item.id_, item.geom, item.obj)
 ```
+
+Current index IDs are intended for immediate lookups such as `blocks.get(id_)`.
+They can change when the group rebuilds its internal tree after bounds expansion
+or an explicit `blocks.rebuild()`.
 
 pygame is not a required dependency for core `fastquadtree`; install a
 pygame-compatible package such as `pygame-ce` only if you use this integration.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -131,7 +131,7 @@ blocks.add(enemy_sprite)
 hits = fpygame.spritecollide(player, blocks, dokill=False)
 
 # Rectangle queries can use pygame.Rect or (min_x, min_y, max_x, max_y) bounds.
-visible = blocks.query_rect(camera_rect, sync=False)
+visible = blocks.query(camera_rect, sync=False)
 for sprite in visible:
     screen.blit(sprite.image, sprite.rect.move(-camera_x, -camera_y))
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -125,7 +125,7 @@ import fastquadtree.pygame as fpygame
 world_bounds = (0, 0, 2000, 2000)
 blocks = fpygame.Group(bounds=world_bounds)
 blocks.add(block_sprites)
-enemy_id = blocks.insert(enemy_sprite)  # Add one sprite and get its current index ID.
+blocks.add(enemy_sprite)
 
 # Collision helper with the same shape as pygame.sprite.spritecollide.
 hits = fpygame.spritecollide(player, blocks, dokill=False)
@@ -135,15 +135,11 @@ visible = blocks.query_rect(camera_rect, sync=False)
 for sprite in visible:
     screen.blit(sprite.image, sprite.rect.move(-camera_x, -camera_y))
 
-# Direct spatial queries return RectItem objects with item.obj set to the sprite.
+# Direct spatial queries return sprites.
 nearest = blocks.nearest_neighbors(player.rect.center, k=5)
-for item in nearest:
-    print(item.id_, item.geom, item.obj)
+for sprite in nearest:
+    print(sprite)
 ```
-
-Current index IDs are intended for immediate lookups such as `blocks.get(id_)`.
-They can change when the group rebuilds its internal tree after bounds expansion
-or an explicit `blocks.rebuild()`.
 
 pygame is not a required dependency for core `fastquadtree`; install a
 pygame-compatible package such as `pygame-ce` only if you use this integration.

--- a/docs/runnables.md
+++ b/docs/runnables.md
@@ -62,7 +62,7 @@ uv run python interactive/ballpit.py
 ![Ballpit_Demo_Screenshot](https://raw.githubusercontent.com/Elan456/fastquadtree/main/assets/ballpit.png)
 
 ## 3. Pygame sprite group comparison
-- Compare `pygame.sprite.Group` with the mostly drop-in `fastquadtree.pygame.Group`
+- Compare `pygame.sprite.Group` with the quadtree-backed `fastquadtree.pygame.Group`
 - Press `G` to switch group backends while the demo is running
 - Uses the fastquadtree-backed group for automatic broadphase culling
 

--- a/docs/runnables.md
+++ b/docs/runnables.md
@@ -70,7 +70,7 @@ This demo creates many static block sprites and a moving player. Player
 collision uses the normal `spritecollide(...)` flow for both backends. Viewport
 culling asks "which blocks intersect the camera rect?" The pygame backend
 answers by scanning every block, while the fastquadtree backend can answer the
-same rectangle query through `Group.query_rect(...)`.
+same rectangle query through `Group.query(...)`.
 
 The performance tradeoff is tree maintenance. The demo uses static blocks, so
 the fastquadtree group can reuse its index frame after frame. If most indexed

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,7 @@ nav:
   - Benchmark: benchmark.md
   - Future Features: future_features.md
   - Rust Usage: rust_usage.md
+  - Engine Defaults: engine_defaults.md
   - API:
       - QuadTree: api/quadtree.md
       - RectQuadTree: api/rect_quadtree.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ compatibility = "manylinux_2_28"
 # uv sync will install the "dev" group by default.
 [dependency-groups]
 dev = [  # Testing and build dependencies
-  "ruff>=0.6.0",
+  "ruff>=0.15.15",
   "pytest>=8.4.2",
   "pytest-cov>=7.0.0",
   "coverage>=7.5",

--- a/pysrc/fastquadtree/_base_quadtree.py
+++ b/pysrc/fastquadtree/_base_quadtree.py
@@ -296,7 +296,8 @@ class _BaseQuadTree(Generic[G], ABC):
         """
         Return the maximum depth of the quadtree.
 
-        Useful if you constructed with max_depth=None.
+        Useful if you constructed with max_depth=None and want to inspect the
+        resolved engine default.
         """
         return self._native.get_max_depth()
 

--- a/pysrc/fastquadtree/_base_quadtree_objects.py
+++ b/pysrc/fastquadtree/_base_quadtree_objects.py
@@ -692,7 +692,8 @@ class _BaseQuadTreeObjects(Generic[G, ItemType], ABC):
         """
         Return the maximum depth of the quadtree.
 
-        Useful if you constructed with max_depth=None.
+        Useful if you constructed with max_depth=None and want to inspect the
+        resolved engine default.
         """
         return self._native.get_max_depth()
 

--- a/pysrc/fastquadtree/point_quadtree.py
+++ b/pysrc/fastquadtree/point_quadtree.py
@@ -29,7 +29,8 @@ class QuadTree(_BaseQuadTree[Point]):
     Args:
         bounds: World bounds as (min_x, min_y, max_x, max_y).
         capacity: Maximum points per node before splitting.
-        max_depth: Optional maximum tree depth (uses engine default if not specified).
+        max_depth: Optional maximum tree depth. If omitted, uses the
+            [engine default](../engine_defaults.md#max-depth).
         dtype: Coordinate data type ('f32', 'f64', 'i32', 'i64'). Default: 'f32'.
 
     Performance:

--- a/pysrc/fastquadtree/point_quadtree.py
+++ b/pysrc/fastquadtree/point_quadtree.py
@@ -30,7 +30,7 @@ class QuadTree(_BaseQuadTree[Point]):
         bounds: World bounds as (min_x, min_y, max_x, max_y).
         capacity: Maximum points per node before splitting.
         max_depth: Optional maximum tree depth. If omitted, uses the
-            [engine default](../engine_defaults.md#max-depth).
+            [engine default](https://elan456.github.io/fastquadtree/engine_defaults/#max-depth).
         dtype: Coordinate data type ('f32', 'f64', 'i32', 'i64'). Default: 'f32'.
 
     Performance:

--- a/pysrc/fastquadtree/point_quadtree_objects.py
+++ b/pysrc/fastquadtree/point_quadtree_objects.py
@@ -29,7 +29,7 @@ class QuadTreeObjects(_BaseQuadTreeObjects[Point, PointItem]):
         bounds: World bounds as (min_x, min_y, max_x, max_y).
         capacity: Maximum points per node before splitting.
         max_depth: Optional maximum tree depth. If omitted, uses the
-            [engine default](../engine_defaults.md#max-depth).
+            [engine default](https://elan456.github.io/fastquadtree/engine_defaults/#max-depth).
         dtype: Coordinate data type ('f32', 'f64', 'i32', 'i64'). Default: 'f32'.
 
     Performance:

--- a/pysrc/fastquadtree/point_quadtree_objects.py
+++ b/pysrc/fastquadtree/point_quadtree_objects.py
@@ -28,7 +28,8 @@ class QuadTreeObjects(_BaseQuadTreeObjects[Point, PointItem]):
     Args:
         bounds: World bounds as (min_x, min_y, max_x, max_y).
         capacity: Maximum points per node before splitting.
-        max_depth: Optional maximum tree depth (uses engine default if not specified).
+        max_depth: Optional maximum tree depth. If omitted, uses the
+            [engine default](../engine_defaults.md#max-depth).
         dtype: Coordinate data type ('f32', 'f64', 'i32', 'i64'). Default: 'f32'.
 
     Performance:

--- a/pysrc/fastquadtree/pygame.py
+++ b/pysrc/fastquadtree/pygame.py
@@ -496,6 +496,9 @@ class Group(_pygame.sprite.Group):
         """
         Return indexed sprites whose rects intersect ``rect``.
 
+        This method is kept for backward compatibility with fastquadtree 2.3.0.
+        For new code, prefer ``query(...)``.
+
         Args:
             rect: Query rectangle. Accepts a ``pygame.Rect`` or a bounds tuple
                 ``(min_x, min_y, max_x, max_y)``.

--- a/pysrc/fastquadtree/pygame.py
+++ b/pysrc/fastquadtree/pygame.py
@@ -28,7 +28,6 @@ except ImportError as exc:
     ) from exc
 
 from ._common import Bounds, Point, QuadTreeDType, validate_bounds
-from ._item import RectItem
 from .rect_quadtree_objects import RectQuadTreeObjects
 
 __all__ = ["Group", "groupcollide", "spritecollide", "spritecollideany"]
@@ -175,11 +174,6 @@ class Group(_pygame.sprite.Group):
     of the world. The same index can also be queried directly with methods such
     as ``query(...)`` and ``nearest_neighbors(...)``.
 
-    ``insert(sprite)`` is available when you want to add one sprite and receive
-    its current quadtree ID. For batches, prefer pygame's normal ``add(...)``.
-    Current index IDs can change when the group rebuilds its tree, for example
-    after bounds expansion or an explicit ``rebuild()``.
-
     For stable runtime behavior, pass explicit world bounds. If ``bounds`` is
     omitted, the group infers bounds from initial sprites and expands/rebuilds
     when later sprites fall outside the current index.
@@ -201,7 +195,7 @@ class Group(_pygame.sprite.Group):
 
         enemies = fpygame.Group(bounds=(0, 0, 2000, 2000))
         enemies.add(enemy_sprites)
-        enemy_id = enemies.insert(boss)
+        enemies.add(boss)
 
         hits = fpygame.spritecollide(player, enemies, dokill=False)
         first_hit = fpygame.spritecollideany(player, enemies)
@@ -264,34 +258,6 @@ class Group(_pygame.sprite.Group):
     def indexed_count(self) -> int:
         """Number of sprites currently indexed by usable rect bounds."""
         return len(self._indexed_rects)
-
-    def insert(self, sprite: _pygame.sprite.Sprite) -> int:
-        """
-        Add one sprite and return its current quadtree ID.
-
-        The sprite must have a usable ``pygame.Rect`` in ``sprite.rect``. Use
-        ``add(...)`` when you want pygame's permissive group behavior for
-        batches or sprites that may not be spatially indexable.
-
-        Args:
-            sprite: Sprite to add and index.
-
-        Returns:
-            int: Current quadtree ID for the sprite.
-
-        Raises:
-            ValueError: If the sprite does not have a usable ``pygame.Rect``.
-            RuntimeError: If the sprite could not be found after insertion.
-        """
-        if _sprite_bounds(sprite) is None:
-            raise ValueError("sprite must have a usable pygame.Rect in sprite.rect")
-
-        self.add(sprite)
-        rect_bounds = cast(Bounds, _sprite_bounds(sprite))
-        id_ = self._find_sprite_id(sprite, rect_bounds)
-        if id_ is None:
-            raise RuntimeError("sprite was added but not found in the quadtree index")
-        return id_
 
     def copy(self) -> Group:
         """Return a new indexed group with the same sprites and index settings."""
@@ -431,12 +397,10 @@ class Group(_pygame.sprite.Group):
             self._index_sprite(sprite, rect_bounds=new_bounds)
         else:
             assert self._tree is not None
-            id_ = self._find_sprite_id(sprite, old_bounds)
-            if id_ is None:
+            if not self._tree.update_by_object(sprite, *new_bounds):
                 self._indexed_rects.pop(sprite, None)
                 self._index_sprite(sprite, rect_bounds=new_bounds)
                 return
-            self._tree.update(id_, *new_bounds)
             self._indexed_rects[sprite] = new_bounds
 
     def _sync_many(self, sprites: Iterable[_pygame.sprite.Sprite]) -> None:
@@ -480,25 +444,21 @@ class Group(_pygame.sprite.Group):
             if old_bounds is None:
                 self._index_sprite(sprite, rect_bounds=rect_bounds)
             else:
-                id_ = self._find_sprite_id(sprite, old_bounds)
-                if id_ is None:
+                assert self._tree is not None
+                if not self._tree.update_by_object(sprite, *rect_bounds):
                     self._indexed_rects.pop(sprite, None)
                     self._index_sprite(sprite, rect_bounds=rect_bounds)
                 else:
-                    assert self._tree is not None
-                    self._tree.update(id_, *rect_bounds)
                     self._indexed_rects[sprite] = rect_bounds
 
     def query(
         self, rect: _pygame.Rect | Bounds, *, sync: bool = True
-    ) -> list[RectItem]:
+    ) -> list[_pygame.sprite.Sprite]:
         """
-        Return indexed item wrappers whose sprite rects intersect ``rect``.
+        Return indexed sprites whose rects intersect ``rect``.
 
-        This is the ``RectQuadTreeObjects``-style query API for pygame sprites.
-        Each returned ``RectItem.obj`` is the sprite, and ``RectItem.geom`` is
-        the indexed rect bounds. Use ``query_rect(...)`` when you only need the
-        sprites.
+        This is a direct spatial query over the group's internal quadtree.
+        It returns pygame sprites, not quadtree IDs or item wrappers.
 
         Args:
             rect: Query rectangle. Accepts a ``pygame.Rect`` or bounds tuple
@@ -506,7 +466,9 @@ class Group(_pygame.sprite.Group):
             sync: When true, synchronize the group before querying.
 
         Returns:
-            list[RectItem]: Indexed items whose rects intersect ``rect``.
+            list[pygame.sprite.Sprite]: Sprites whose indexed rects intersect
+                ``rect``. Returns an empty list if the query rectangle cannot
+                be interpreted or does not overlap the current world bounds.
         """
         if sync:
             self.sync()
@@ -523,22 +485,14 @@ class Group(_pygame.sprite.Group):
             return []
 
         return [
-            item
+            cast(_pygame.sprite.Sprite, item.obj)
             for item in self._tree.query(clipped_bounds)
             if item.obj is not None and self.has_internal(item.obj)
         ]
 
-    def query_ids(self, rect: _pygame.Rect | Bounds, *, sync: bool = True) -> list[int]:
-        """
-        Return current quadtree IDs for indexed sprites intersecting ``rect``.
-
-        Current index IDs can change after tree rebuilds.
-        """
-        return [item.id_ for item in self.query(rect, sync=sync)]
-
     def query_rect(
         self, rect: _pygame.Rect | Bounds, *, sync: bool = True
-    ) -> list[Any]:
+    ) -> list[_pygame.sprite.Sprite]:
         """
         Return indexed sprites whose rects intersect ``rect``.
 
@@ -548,17 +502,19 @@ class Group(_pygame.sprite.Group):
             sync: When true, synchronize the group before querying.
 
         Returns:
-            list[Any]: Sprites whose indexed rects intersect ``rect``. Returns
-                an empty list if the query rectangle cannot be interpreted or
-                does not overlap the current world bounds. Queries that
-                partially extend outside the world bounds are clamped before
-                searching.
+            list[pygame.sprite.Sprite]: Sprites whose indexed rects intersect
+                ``rect``. Returns an empty list if the query rectangle cannot
+                be interpreted or does not overlap the current world bounds.
+                Queries that partially extend outside the world bounds are
+                clamped before searching.
         """
-        return [item.obj for item in self.query(rect, sync=sync)]
+        return self.query(rect, sync=sync)
 
-    def nearest_neighbor(self, point: Point, *, sync: bool = True) -> RectItem | None:
+    def nearest_neighbor(
+        self, point: Point, *, sync: bool = True
+    ) -> _pygame.sprite.Sprite | None:
         """
-        Return the nearest indexed sprite rect to ``point``.
+        Return the sprite with the nearest indexed rect to ``point``.
 
         Distance is measured like ``RectQuadTreeObjects``: Euclidean distance
         from the point to the nearest edge of each rectangle, or zero when the
@@ -569,17 +525,17 @@ class Group(_pygame.sprite.Group):
             sync: When true, synchronize the group before querying.
 
         Returns:
-            RectItem | None: Nearest item with ``obj`` set to the sprite, or
-                ``None`` if no sprites are indexed.
+            pygame.sprite.Sprite | None: Nearest indexed sprite, or ``None`` if
+                no sprites are indexed.
         """
         neighbors = self.nearest_neighbors(point, 1, sync=sync)
         return neighbors[0] if neighbors else None
 
     def nearest_neighbors(
         self, point: Point, k: int, *, sync: bool = True
-    ) -> list[RectItem]:
+    ) -> list[_pygame.sprite.Sprite]:
         """
-        Return the ``k`` nearest indexed sprite rects to ``point``.
+        Return sprites with the ``k`` nearest indexed rects to ``point``.
 
         Args:
             point: Query point as ``(x, y)``.
@@ -587,8 +543,7 @@ class Group(_pygame.sprite.Group):
             sync: When true, synchronize the group before querying.
 
         Returns:
-            list[RectItem]: Items in increasing distance order. Each item's
-                ``obj`` is the sprite.
+            list[pygame.sprite.Sprite]: Sprites in increasing distance order.
         """
         if sync:
             self.sync()
@@ -601,35 +556,10 @@ class Group(_pygame.sprite.Group):
             return []
 
         return [
-            item
+            cast(_pygame.sprite.Sprite, item.obj)
             for item in self._tree.nearest_neighbors(point, k)
             if item.obj is not None and self.has_internal(item.obj)
         ]
-
-    def get(self, id_: int) -> Any | None:
-        """
-        Return the sprite for a current quadtree ID, or ``None`` if not found.
-
-        Current index IDs can change after tree rebuilds.
-        """
-        if self._tree is None:
-            return None
-        obj = self._tree.get(id_)
-        return obj if obj is not None and self.has_internal(obj) else None
-
-    def get_all_items(self) -> list[RectItem]:
-        """Return all current indexed ``RectItem`` wrappers for group sprites."""
-        if self._tree is None:
-            return []
-        return [
-            item
-            for item in self._tree.get_all_items()
-            if item.obj is not None and self.has_internal(item.obj)
-        ]
-
-    def get_all_objects(self) -> list[Any]:
-        """Return all sprites currently present in the quadtree index."""
-        return [item.obj for item in self.get_all_items()]
 
     def _clear_index(self, *, preserve_tree: bool = False) -> None:
         self._indexed_rects.clear()
@@ -643,9 +573,7 @@ class Group(_pygame.sprite.Group):
         if old_bounds is None or self._tree is None:
             return
 
-        id_ = self._find_sprite_id(sprite, old_bounds)
-        if id_ is not None:
-            self._tree.delete(id_)
+        self._tree.delete_one_by_object(sprite)
 
     def _index_sprite(
         self, sprite: _pygame.sprite.Sprite, rect_bounds: Bounds | None = None
@@ -664,17 +592,6 @@ class Group(_pygame.sprite.Group):
         self._tree.insert(rect_bounds, obj=sprite)
         self._indexed_rects[sprite] = rect_bounds
         self._sprites_without_rect.discard(sprite)
-
-    def _find_sprite_id(
-        self, sprite: _pygame.sprite.Sprite, rect_bounds: Bounds
-    ) -> int | None:
-        if self._tree is None:
-            return None
-
-        for item in self._tree.query(rect_bounds):
-            if item.obj is sprite and item.geom == rect_bounds:
-                return item.id_
-        return None
 
     def _ensure_tree_contains(self, rect: Bounds) -> None:
         if self._bounds is not None and _contains_rect(self._bounds, rect):

--- a/pysrc/fastquadtree/pygame.py
+++ b/pysrc/fastquadtree/pygame.py
@@ -1,10 +1,9 @@
 """
 pygame sprite-group integration backed by a rectangle quadtree.
 
-This module provides ``fastquadtree.pygame.Group``, a replacement for
-``pygame.sprite.Group`` that keeps a ``RectQuadTreeObjects`` index of each
-sprite's ``rect``. The collision helpers mirror pygame's sprite collision APIs
-and use the index as a broadphase when it is safe to do so.
+This module provides pygame-facing spatial-index utilities for accelerating
+sprite collision checks: ``Group``, ``spritecollide(...)``,
+``spritecollideany(...)``, and ``groupcollide(...)``.
 
 When the accelerated broadphase is used, collision result order follows the
 quadtree query traversal and is not guaranteed to match pygame group iteration
@@ -12,17 +11,6 @@ order.
 
 Core ``fastquadtree`` APIs do not require pygame. Importing this integration
 module does require pygame or a compatible package such as ``pygame-ce``.
-
-Example:
-    ```python
-    import fastquadtree.pygame as fpygame
-
-    enemies = fpygame.Group(bounds=(0, 0, 2000, 2000))
-    enemies.add(enemy_sprites)
-
-    hits = fpygame.spritecollide(player, enemies, dokill=False)
-    first_hit = fpygame.spritecollideany(player, enemies)
-    ```
 """
 
 from __future__ import annotations
@@ -39,7 +27,8 @@ except ImportError as exc:
         "Pygame is not installed. Install pygame to use the fastquadtree.pygame integration features."
     ) from exc
 
-from ._common import Bounds, QuadTreeDType, validate_bounds
+from ._common import Bounds, Point, QuadTreeDType, validate_bounds
+from ._item import RectItem
 from .rect_quadtree_objects import RectQuadTreeObjects
 
 __all__ = ["Group", "groupcollide", "spritecollide", "spritecollideany"]
@@ -170,12 +159,26 @@ def _expanded_bounds(
 
 class Group(_pygame.sprite.Group):
     """
-    pygame sprite group with a ``RectQuadTreeObjects`` broadphase index.
+    pygame sprite group with a ``RectQuadTreeObjects`` spatial index.
+
+    This is a sprite-oriented ``RectQuadTreeObjects`` integration: indexed
+    entries use each sprite's ``rect`` as geometry and the sprite itself as the
+    associated object. The index is primarily a collision broadphase: collision
+    helpers first query the quadtree for nearby rects, then run pygame's normal
+    rect collision checks only on those candidates instead of scanning every
+    sprite in the group.
 
     ``Group`` behaves like ``pygame.sprite.Group`` for normal operations such as
     ``add``, ``remove``, ``empty``, iteration, membership checks, ``update``,
-    and ``draw``. In parallel, it indexes sprites with usable ``rect`` bounds so
-    the module-level collision helpers can avoid scanning every sprite.
+    and ``draw``. In parallel, it indexes sprites with usable ``rect`` bounds to
+    accelerate collision-heavy scenes where each query touches only a small part
+    of the world. The same index can also be queried directly with methods such
+    as ``query(...)`` and ``nearest_neighbors(...)``.
+
+    ``insert(sprite)`` is available when you want to add one sprite and receive
+    its current quadtree ID. For batches, prefer pygame's normal ``add(...)``.
+    Current index IDs can change when the group rebuilds its tree, for example
+    after bounds expansion or an explicit ``rebuild()``.
 
     For stable runtime behavior, pass explicit world bounds. If ``bounds`` is
     omitted, the group infers bounds from initial sprites and expands/rebuilds
@@ -195,9 +198,16 @@ class Group(_pygame.sprite.Group):
     Example:
         ```python
         import fastquadtree.pygame as fpygame
-        group = fpygame.Group(bounds=(0, 0, 1000, 1000))
-        group.add(enemies)
-        hits = fpygame.spritecollide(player, group, dokill=False)
+
+        enemies = fpygame.Group(bounds=(0, 0, 2000, 2000))
+        enemies.add(enemy_sprites)
+        enemy_id = enemies.insert(boss)
+
+        hits = fpygame.spritecollide(player, enemies, dokill=False)
+        first_hit = fpygame.spritecollideany(player, enemies)
+
+        visible = enemies.query_rect(camera_rect)
+        nearest = enemies.nearest_neighbors(player.rect.center, k=5)
         ```
     """
 
@@ -254,6 +264,34 @@ class Group(_pygame.sprite.Group):
     def indexed_count(self) -> int:
         """Number of sprites currently indexed by usable rect bounds."""
         return len(self._indexed_rects)
+
+    def insert(self, sprite: _pygame.sprite.Sprite) -> int:
+        """
+        Add one sprite and return its current quadtree ID.
+
+        The sprite must have a usable ``pygame.Rect`` in ``sprite.rect``. Use
+        ``add(...)`` when you want pygame's permissive group behavior for
+        batches or sprites that may not be spatially indexable.
+
+        Args:
+            sprite: Sprite to add and index.
+
+        Returns:
+            int: Current quadtree ID for the sprite.
+
+        Raises:
+            ValueError: If the sprite does not have a usable ``pygame.Rect``.
+            RuntimeError: If the sprite could not be found after insertion.
+        """
+        if _sprite_bounds(sprite) is None:
+            raise ValueError("sprite must have a usable pygame.Rect in sprite.rect")
+
+        self.add(sprite)
+        rect_bounds = cast(Bounds, _sprite_bounds(sprite))
+        id_ = self._find_sprite_id(sprite, rect_bounds)
+        if id_ is None:
+            raise RuntimeError("sprite was added but not found in the quadtree index")
+        return id_
 
     def copy(self) -> Group:
         """Return a new indexed group with the same sprites and index settings."""
@@ -451,6 +489,53 @@ class Group(_pygame.sprite.Group):
                     self._tree.update(id_, *rect_bounds)
                     self._indexed_rects[sprite] = rect_bounds
 
+    def query(
+        self, rect: _pygame.Rect | Bounds, *, sync: bool = True
+    ) -> list[RectItem]:
+        """
+        Return indexed item wrappers whose sprite rects intersect ``rect``.
+
+        This is the ``RectQuadTreeObjects``-style query API for pygame sprites.
+        Each returned ``RectItem.obj`` is the sprite, and ``RectItem.geom`` is
+        the indexed rect bounds. Use ``query_rect(...)`` when you only need the
+        sprites.
+
+        Args:
+            rect: Query rectangle. Accepts a ``pygame.Rect`` or bounds tuple
+                ``(min_x, min_y, max_x, max_y)``.
+            sync: When true, synchronize the group before querying.
+
+        Returns:
+            list[RectItem]: Indexed items whose rects intersect ``rect``.
+        """
+        if sync:
+            self.sync()
+
+        rect_bounds = _query_to_bounds(rect)
+        if rect_bounds is None:
+            return []
+
+        if self._tree is None:
+            return []
+
+        clipped_bounds = _intersect_bounds(cast(Bounds, self._bounds), rect_bounds)
+        if clipped_bounds is None:
+            return []
+
+        return [
+            item
+            for item in self._tree.query(clipped_bounds)
+            if item.obj is not None and self.has_internal(item.obj)
+        ]
+
+    def query_ids(self, rect: _pygame.Rect | Bounds, *, sync: bool = True) -> list[int]:
+        """
+        Return current quadtree IDs for indexed sprites intersecting ``rect``.
+
+        Current index IDs can change after tree rebuilds.
+        """
+        return [item.id_ for item in self.query(rect, sync=sync)]
+
     def query_rect(
         self, rect: _pygame.Rect | Bounds, *, sync: bool = True
     ) -> list[Any]:
@@ -469,27 +554,82 @@ class Group(_pygame.sprite.Group):
                 partially extend outside the world bounds are clamped before
                 searching.
         """
+        return [item.obj for item in self.query(rect, sync=sync)]
+
+    def nearest_neighbor(self, point: Point, *, sync: bool = True) -> RectItem | None:
+        """
+        Return the nearest indexed sprite rect to ``point``.
+
+        Distance is measured like ``RectQuadTreeObjects``: Euclidean distance
+        from the point to the nearest edge of each rectangle, or zero when the
+        point is inside a rectangle.
+
+        Args:
+            point: Query point as ``(x, y)``.
+            sync: When true, synchronize the group before querying.
+
+        Returns:
+            RectItem | None: Nearest item with ``obj`` set to the sprite, or
+                ``None`` if no sprites are indexed.
+        """
+        neighbors = self.nearest_neighbors(point, 1, sync=sync)
+        return neighbors[0] if neighbors else None
+
+    def nearest_neighbors(
+        self, point: Point, k: int, *, sync: bool = True
+    ) -> list[RectItem]:
+        """
+        Return the ``k`` nearest indexed sprite rects to ``point``.
+
+        Args:
+            point: Query point as ``(x, y)``.
+            k: Number of neighbors to return.
+            sync: When true, synchronize the group before querying.
+
+        Returns:
+            list[RectItem]: Items in increasing distance order. Each item's
+                ``obj`` is the sprite.
+        """
         if sync:
             self.sync()
 
-        rect_bounds = _query_to_bounds(rect)
-        if rect_bounds is None:
-            return []
-
         if self._tree is None:
             return []
-
-        clipped_bounds = _intersect_bounds(cast(Bounds, self._bounds), rect_bounds)
-        if clipped_bounds is None:
+        if k <= 0:
             return []
-        rect_bounds = clipped_bounds
+        if not self._indexed_rects:
+            return []
 
-        objects: list[Any] = []
-        for id_ in self._tree.query_ids(rect_bounds):
-            obj = self._tree.get(id_)
-            if obj is not None:
-                objects.append(obj)
-        return objects
+        return [
+            item
+            for item in self._tree.nearest_neighbors(point, k)
+            if item.obj is not None and self.has_internal(item.obj)
+        ]
+
+    def get(self, id_: int) -> Any | None:
+        """
+        Return the sprite for a current quadtree ID, or ``None`` if not found.
+
+        Current index IDs can change after tree rebuilds.
+        """
+        if self._tree is None:
+            return None
+        obj = self._tree.get(id_)
+        return obj if obj is not None and self.has_internal(obj) else None
+
+    def get_all_items(self) -> list[RectItem]:
+        """Return all current indexed ``RectItem`` wrappers for group sprites."""
+        if self._tree is None:
+            return []
+        return [
+            item
+            for item in self._tree.get_all_items()
+            if item.obj is not None and self.has_internal(item.obj)
+        ]
+
+    def get_all_objects(self) -> list[Any]:
+        """Return all sprites currently present in the quadtree index."""
+        return [item.obj for item in self.get_all_items()]
 
     def _clear_index(self, *, preserve_tree: bool = False) -> None:
         self._indexed_rects.clear()

--- a/pysrc/fastquadtree/pygame.py
+++ b/pysrc/fastquadtree/pygame.py
@@ -499,7 +499,8 @@ class Group(_pygame.sprite.Group):
         """
         warnings.warn(
             "fastquadtree.pygame.Group.query_rect() is deprecated and will be "
-            "removed in fastquadtree 3.0. Use Group.query() instead.",
+            "removed if fastquadtree 3.0 introduces breaking API cleanup. "
+            "Use Group.query() instead.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/pysrc/fastquadtree/pygame.py
+++ b/pysrc/fastquadtree/pygame.py
@@ -195,7 +195,8 @@ class Group(_pygame.sprite.Group):
         *sprites: Initial sprites, pygame groups, or sprite iterables to add.
         bounds: Optional world bounds as ``(min_x, min_y, max_x, max_y)``.
         capacity: Maximum indexed rectangles per quadtree node before splitting.
-        max_depth: Optional maximum quadtree depth.
+        max_depth: Optional maximum quadtree depth. If omitted, uses the
+            [engine default](../engine_defaults.md#max-depth).
         dtype: Coordinate data type (``"f32"``, ``"f64"``, ``"i32"``,
             ``"i64"``). Default: ``"f32"``.
         rebuild_on_update: When true, ``Group.update(...)`` rebuilds the whole

--- a/pysrc/fastquadtree/pygame.py
+++ b/pysrc/fastquadtree/pygame.py
@@ -196,7 +196,7 @@ class Group(_pygame.sprite.Group):
         bounds: Optional world bounds as ``(min_x, min_y, max_x, max_y)``.
         capacity: Maximum indexed rectangles per quadtree node before splitting.
         max_depth: Optional maximum quadtree depth. If omitted, uses the
-            [engine default](../engine_defaults.md#max-depth).
+            [engine default](https://elan456.github.io/fastquadtree/engine_defaults/#max-depth).
         dtype: Coordinate data type (``"f32"``, ``"f64"``, ``"i32"``,
             ``"i64"``). Default: ``"f32"``.
         rebuild_on_update: When true, ``Group.update(...)`` rebuilds the whole

--- a/pysrc/fastquadtree/pygame.py
+++ b/pysrc/fastquadtree/pygame.py
@@ -494,22 +494,8 @@ class Group(_pygame.sprite.Group):
         self, rect: _pygame.Rect | Bounds, *, sync: bool = True
     ) -> list[_pygame.sprite.Sprite]:
         """
-        Return indexed sprites whose rects intersect ``rect``.
-
         This method is kept for backward compatibility with fastquadtree 2.3.0.
         For new code, prefer ``query(...)``.
-
-        Args:
-            rect: Query rectangle. Accepts a ``pygame.Rect`` or a bounds tuple
-                ``(min_x, min_y, max_x, max_y)``.
-            sync: When true, synchronize the group before querying.
-
-        Returns:
-            list[pygame.sprite.Sprite]: Sprites whose indexed rects intersect
-                ``rect``. Returns an empty list if the query rectangle cannot
-                be interpreted or does not overlap the current world bounds.
-                Queries that partially extend outside the world bounds are
-                clamped before searching.
         """
         return self.query(rect, sync=sync)
 

--- a/pysrc/fastquadtree/pygame.py
+++ b/pysrc/fastquadtree/pygame.py
@@ -200,7 +200,7 @@ class Group(_pygame.sprite.Group):
         hits = fpygame.spritecollide(player, enemies, dokill=False)
         first_hit = fpygame.spritecollideany(player, enemies)
 
-        visible = enemies.query_rect(camera_rect)
+        visible = enemies.query(camera_rect)
         nearest = enemies.nearest_neighbors(player.rect.center, k=5)
         ```
     """
@@ -497,6 +497,12 @@ class Group(_pygame.sprite.Group):
         This method is kept for backward compatibility with fastquadtree 2.3.0.
         For new code, prefer ``query(...)``.
         """
+        warnings.warn(
+            "fastquadtree.pygame.Group.query_rect() is deprecated and will be "
+            "removed in fastquadtree 3.0. Use Group.query() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.query(rect, sync=sync)
 
     def nearest_neighbor(
@@ -680,7 +686,7 @@ def spritecollide(
     if group._sprites_without_rect:
         return _pygame.sprite.spritecollide(sprite, group, dokill, collided)
 
-    candidates = group.query_rect(query_rect, sync=False)
+    candidates = group.query(query_rect, sync=False)
     collided_sprites = [
         candidate for candidate in candidates if sprite.rect.colliderect(candidate.rect)
     ]
@@ -738,7 +744,7 @@ def spritecollideany(
     if query_rect is None or group._sprites_without_rect:
         return _pygame.sprite.spritecollideany(sprite, group, collided)
 
-    for candidate in group.query_rect(query_rect, sync=False):
+    for candidate in group.query(query_rect, sync=False):
         if sprite.rect.colliderect(candidate.rect):
             return candidate
     return None

--- a/pysrc/fastquadtree/pygame.py
+++ b/pysrc/fastquadtree/pygame.py
@@ -466,9 +466,7 @@ class Group(_pygame.sprite.Group):
             sync: When true, synchronize the group before querying.
 
         Returns:
-            list[pygame.sprite.Sprite]: Sprites whose indexed rects intersect
-                ``rect``. Returns an empty list if the query rectangle cannot
-                be interpreted or does not overlap the current world bounds.
+            Sprites whose indexed rects intersect ``rect``. Returns an empty list for invalid or out-of-bounds queries.
         """
         if sync:
             self.sync()
@@ -521,8 +519,7 @@ class Group(_pygame.sprite.Group):
             sync: When true, synchronize the group before querying.
 
         Returns:
-            pygame.sprite.Sprite | None: Nearest indexed sprite, or ``None`` if
-                no sprites are indexed.
+            Nearest indexed sprite, or ``None`` if no sprites are indexed.
         """
         neighbors = self.nearest_neighbors(point, 1, sync=sync)
         return neighbors[0] if neighbors else None
@@ -539,7 +536,7 @@ class Group(_pygame.sprite.Group):
             sync: When true, synchronize the group before querying.
 
         Returns:
-            list[pygame.sprite.Sprite]: Sprites in increasing distance order.
+            Sprites in increasing distance order.
         """
         if sync:
             self.sync()
@@ -666,9 +663,7 @@ def spritecollide(
             latest sprite rect changes.
 
     Returns:
-        list[Any]: Collided sprites. When the quadtree broadphase is used,
-            result order is not deterministic and may differ from pygame group
-            iteration order.
+        Collided sprites. When the quadtree broadphase is used, result order is not deterministic and may differ from pygame group iteration order.
     """
     if not isinstance(group, Group):
         return _pygame.sprite.spritecollide(sprite, group, dokill, collided)
@@ -725,9 +720,7 @@ def spritecollideany(
             latest sprite rect changes.
 
     Returns:
-        Any | None: The first collided sprite, or ``None``. When the quadtree
-            broadphase is used, "first" means first in quadtree query order,
-            not pygame group iteration order.
+        The first collided sprite, or ``None``. When the quadtree broadphase is used, "first" means first in quadtree query order.
     """
 
     if not isinstance(group, Group):
@@ -782,10 +775,7 @@ def groupcollide(
             latest sprite rect changes.
 
     Returns:
-        dict[Any, list[Any]]: Mapping from each collided sprite in ``groupa`` to
-            its collided sprites from ``groupb``. When the quadtree broadphase
-            is used, each list follows quadtree query order, not pygame group
-            iteration order.
+        Mapping from each collided sprite in ``groupa`` to its collided sprites from ``groupb``. When the quadtree broadphase is used, each list follows quadtree query order.
 
     Example:
         ```python

--- a/pysrc/fastquadtree/pygame.py
+++ b/pysrc/fastquadtree/pygame.py
@@ -38,6 +38,7 @@ _ATOMIC_ITERABLES = (str, bytes, bytearray, memoryview)
 
 
 def _looks_like_bounds(value: Any) -> bool:
+    """Return true when ``value`` looks like a numeric bounds tuple."""
     if not isinstance(value, (list, tuple)):
         return False
     return len(value) == 4 and all(
@@ -46,19 +47,23 @@ def _looks_like_bounds(value: Any) -> bool:
 
 
 def _rect_to_bounds(rect: _pygame.Rect) -> Bounds:
+    """Convert a pygame rect to ``(left, top, right, bottom)`` bounds."""
     return (rect.left, rect.top, rect.right, rect.bottom)
 
 
 def _is_indexable_rect(rect: _pygame.Rect) -> bool:
+    """Return true when a rect has positive width and height."""
     return rect.left < rect.right and rect.top < rect.bottom
 
 
 def _sprite_rect(sprite: Any) -> _pygame.Rect | None:
+    """Return ``sprite.rect`` when it is a pygame rect."""
     rect = getattr(sprite, "rect", None)
     return rect if isinstance(rect, _pygame.Rect) else None
 
 
 def _sprite_bounds(sprite: Any) -> Bounds | None:
+    """Return indexable bounds for a sprite's rect."""
     rect = _sprite_rect(sprite)
     if rect is None or not _is_indexable_rect(rect):
         return None
@@ -66,6 +71,7 @@ def _sprite_bounds(sprite: Any) -> Bounds | None:
 
 
 def _positional_bounds(value: Any) -> Bounds | None:
+    """Return bounds from a positional bounds argument."""
     if isinstance(value, _pygame.Rect):
         return validate_bounds(_rect_to_bounds(value))
     if _looks_like_bounds(value):
@@ -74,6 +80,7 @@ def _positional_bounds(value: Any) -> Bounds | None:
 
 
 def _query_to_bounds(rect: Any) -> Bounds | None:
+    """Return validated query bounds, or ``None`` if unusable."""
     if isinstance(rect, _pygame.Rect) and _is_indexable_rect(rect):
         return _rect_to_bounds(rect)
     if _looks_like_bounds(rect):
@@ -85,12 +92,14 @@ def _query_to_bounds(rect: Any) -> Bounds | None:
 
 
 def _contains_rect(bounds: Bounds, rect: Bounds) -> bool:
+    """Return true when ``bounds`` fully contains ``rect``."""
     min_x, min_y, max_x, max_y = bounds
     left, top, right, bottom = rect
     return min_x <= left and min_y <= top and right <= max_x and bottom <= max_y
 
 
 def _intersect_bounds(left: Bounds, right: Bounds) -> Bounds | None:
+    """Return the non-empty intersection of two bounds."""
     min_x = max(left[0], right[0])
     min_y = max(left[1], right[1])
     max_x = min(left[2], right[2])
@@ -101,10 +110,12 @@ def _intersect_bounds(left: Bounds, right: Bounds) -> Bounds | None:
 
 
 def _is_integer_dtype(dtype: QuadTreeDType) -> bool:
+    """Return true when a quadtree dtype stores integer coordinates."""
     return dtype.startswith("i")
 
 
 def _pad_bounds(bounds: Bounds, dtype: QuadTreeDType = "f32") -> Bounds:
+    """Return bounds expanded with dtype-aware padding."""
     min_x, min_y, max_x, max_y = bounds
     width = max_x - min_x
     height = max_y - min_y
@@ -116,6 +127,7 @@ def _pad_bounds(bounds: Bounds, dtype: QuadTreeDType = "f32") -> Bounds:
 
 
 def _bounds_from_rects(rects: Iterable[Bounds], dtype: QuadTreeDType = "f32") -> Bounds:
+    """Return padded bounds that contain all given rect bounds."""
     rect_list = list(rects)
     if not rect_list:
         if _is_integer_dtype(dtype):
@@ -140,6 +152,7 @@ def _bounds_from_rects(rects: Iterable[Bounds], dtype: QuadTreeDType = "f32") ->
 def _expanded_bounds(
     current: Bounds | None, rect: Bounds, dtype: QuadTreeDType = "f32"
 ) -> Bounds:
+    """Return bounds expanded to contain ``rect``."""
     if current is None:
         return _bounds_from_rects([rect], dtype=dtype)
 
@@ -271,6 +284,7 @@ class Group(_pygame.sprite.Group):
         )
 
     def _new_tree(self, bounds: Bounds) -> RectQuadTreeObjects:
+        """Create a quadtree using this group's index settings."""
         return RectQuadTreeObjects(
             bounds,
             capacity=self._capacity,
@@ -376,6 +390,7 @@ class Group(_pygame.sprite.Group):
         self._sync_sprite(sprite)
 
     def _sync_sprite(self, sprite: _pygame.sprite.Sprite) -> None:
+        """Synchronize one sprite's current rect with the index."""
         rect = _sprite_rect(sprite)
         if rect is None or not _is_indexable_rect(rect):
             self._unindex_sprite(sprite)
@@ -404,6 +419,7 @@ class Group(_pygame.sprite.Group):
             self._indexed_rects[sprite] = new_bounds
 
     def _sync_many(self, sprites: Iterable[_pygame.sprite.Sprite]) -> None:
+        """Synchronize many sprites with one bounds expansion pass."""
         pending: list[tuple[_pygame.sprite.Sprite, Bounds | None, Bounds]] = []
 
         for sprite in sprites:
@@ -555,12 +571,14 @@ class Group(_pygame.sprite.Group):
         ]
 
     def _clear_index(self, *, preserve_tree: bool = False) -> None:
+        """Clear indexed sprite bookkeeping and optionally the tree."""
         self._indexed_rects.clear()
         self._sprites_without_rect.clear()
         if not preserve_tree and self._tree is not None:
             self._tree.clear()
 
     def _unindex_sprite(self, sprite: _pygame.sprite.Sprite) -> None:
+        """Remove one sprite from the quadtree index."""
         old_bounds = self._indexed_rects.pop(sprite, None)
         self._sprites_without_rect.discard(sprite)
         if old_bounds is None or self._tree is None:
@@ -571,6 +589,7 @@ class Group(_pygame.sprite.Group):
     def _index_sprite(
         self, sprite: _pygame.sprite.Sprite, rect_bounds: Bounds | None = None
     ) -> None:
+        """Insert one sprite into the quadtree index when possible."""
         rect = _sprite_rect(sprite)
         if rect is None or not _is_indexable_rect(rect):
             self._sprites_without_rect.add(sprite)
@@ -587,6 +606,7 @@ class Group(_pygame.sprite.Group):
         self._sprites_without_rect.discard(sprite)
 
     def _ensure_tree_contains(self, rect: Bounds) -> None:
+        """Ensure the tree exists and contains ``rect``."""
         if self._bounds is not None and _contains_rect(self._bounds, rect):
             if self._tree is None:
                 self._tree = self._new_tree(self._bounds)
@@ -597,6 +617,7 @@ class Group(_pygame.sprite.Group):
 
 
 def _flatten_sprites(values: Iterable[Any]) -> list[Any]:
+    """Flatten pygame sprites, groups, and nested sprite iterables."""
     flattened: list[Any] = []
     for value in values:
         if isinstance(value, _pygame.sprite.Sprite):
@@ -684,7 +705,7 @@ def spritecollide(
 
     candidates = group.query(query_rect, sync=False)
     collided_sprites = [
-        candidate for candidate in candidates if sprite.rect.colliderect(candidate.rect)
+        candidate for candidate in candidates if query_rect.colliderect(candidate.rect)
     ]
 
     if dokill:
@@ -739,7 +760,7 @@ def spritecollideany(
         return _pygame.sprite.spritecollideany(sprite, group, collided)
 
     for candidate in group.query(query_rect, sync=False):
-        if sprite.rect.colliderect(candidate.rect):
+        if query_rect.colliderect(candidate.rect):
             return candidate
     return None
 

--- a/pysrc/fastquadtree/rect_quadtree.py
+++ b/pysrc/fastquadtree/rect_quadtree.py
@@ -35,7 +35,7 @@ class RectQuadTree(_BaseQuadTree[Bounds]):
         bounds: World bounds as (min_x, min_y, max_x, max_y).
         capacity: Maximum rectangles per node before splitting.
         max_depth: Optional maximum tree depth. If omitted, uses the
-            [engine default](../engine_defaults.md#max-depth).
+            [engine default](https://elan456.github.io/fastquadtree/engine_defaults/#max-depth).
         dtype: Coordinate data type ('f32', 'f64', 'i32', 'i64'). Default: 'f32'.
 
     Performance:

--- a/pysrc/fastquadtree/rect_quadtree.py
+++ b/pysrc/fastquadtree/rect_quadtree.py
@@ -34,7 +34,8 @@ class RectQuadTree(_BaseQuadTree[Bounds]):
     Args:
         bounds: World bounds as (min_x, min_y, max_x, max_y).
         capacity: Maximum rectangles per node before splitting.
-        max_depth: Optional maximum tree depth (uses engine default if not specified).
+        max_depth: Optional maximum tree depth. If omitted, uses the
+            [engine default](../engine_defaults.md#max-depth).
         dtype: Coordinate data type ('f32', 'f64', 'i32', 'i64'). Default: 'f32'.
 
     Performance:

--- a/pysrc/fastquadtree/rect_quadtree_objects.py
+++ b/pysrc/fastquadtree/rect_quadtree_objects.py
@@ -33,7 +33,8 @@ class RectQuadTreeObjects(_BaseQuadTreeObjects[Bounds, RectItem]):
     Args:
         bounds: World bounds as (min_x, min_y, max_x, max_y).
         capacity: Maximum rectangles per node before splitting.
-        max_depth: Optional maximum tree depth (uses engine default if not specified).
+        max_depth: Optional maximum tree depth. If omitted, uses the
+            [engine default](../engine_defaults.md#max-depth).
         dtype: Coordinate data type ('f32', 'f64', 'i32', 'i64'). Default: 'f32'.
 
     Performance:

--- a/pysrc/fastquadtree/rect_quadtree_objects.py
+++ b/pysrc/fastquadtree/rect_quadtree_objects.py
@@ -34,7 +34,7 @@ class RectQuadTreeObjects(_BaseQuadTreeObjects[Bounds, RectItem]):
         bounds: World bounds as (min_x, min_y, max_x, max_y).
         capacity: Maximum rectangles per node before splitting.
         max_depth: Optional maximum tree depth. If omitted, uses the
-            [engine default](../engine_defaults.md#max-depth).
+            [engine default](https://elan456.github.io/fastquadtree/engine_defaults/#max-depth).
         dtype: Coordinate data type ('f32', 'f64', 'i32', 'i64'). Default: 'f32'.
 
     Performance:

--- a/tests/test_python/integration/test_pygame_integration.py
+++ b/tests/test_python/integration/test_pygame_integration.py
@@ -295,6 +295,56 @@ def test_inferred_bounds_growth_set_bounds_rebuild_and_query_rect():
     assert tuple(one_shot) == (0, 0, 10, 10)
 
 
+def test_group_exposes_rect_quadtree_object_api_for_sprites():
+    near = RectSprite((0, 0, 10, 10), "near")
+    mid = RectSprite((40, 40, 10, 10), "mid")
+    far = RectSprite((80, 80, 10, 10), "far")
+    missing = RectSprite(label="missing")
+
+    group = fpygame.Group(bounds=(0, 0, 100, 100))
+    near_id = group.insert(near)
+    group.add(mid, far)
+
+    with pytest.raises(ValueError, match=r"usable pygame\.Rect"):
+        group.insert(missing)
+
+    broken_lookup = fpygame.Group(bounds=(0, 0, 10, 10))
+    broken_lookup._find_sprite_id = lambda sprite, rect_bounds: None
+    with pytest.raises(RuntimeError, match="not found in the quadtree index"):
+        broken_lookup.insert(RectSprite((1, 1, 2, 2)))
+
+    assert group.get(near_id) is near
+    assert group.get(9999) is None
+    assert fpygame.Group().get(near_id) is None
+
+    queried_items = group.query(pygame.Rect(0, 0, 15, 15))
+    assert [item.obj for item in queried_items] == [near]
+    assert group.query_ids((0, 0, 15, 15), sync=False) == [near_id]
+    assert group.query(object()) == []
+    assert group.query((500, 500, 510, 510)) == []
+    assert fpygame.Group().query((0, 0, 1, 1)) == []
+
+    nearest = group.nearest_neighbor((42, 42))
+    assert nearest is not None
+    assert nearest.obj is mid
+    assert [item.obj for item in group.nearest_neighbors((0, 0), 2)] == [near, mid]
+
+    mid.rect.update(2, 2, 10, 10)
+    assert group.nearest_neighbor((11, 11), sync=True).obj is mid
+    assert [item.obj for item in group.nearest_neighbors((0, 0), 0)] == []
+
+    indexed_empty = fpygame.Group(bounds=(0, 0, 10, 10))
+    assert indexed_empty.nearest_neighbor((0, 0)) is None
+    assert indexed_empty.nearest_neighbors((0, 0), 1) == []
+    assert fpygame.Group().nearest_neighbors((0, 0), 1) == []
+    assert fpygame.Group().nearest_neighbors((0, 0), 1, sync=False) == []
+
+    all_items = group.get_all_items()
+    assert {item.obj for item in all_items} == {near, mid, far}
+    assert set(group.get_all_objects()) == {near, mid, far}
+    assert fpygame.Group().get_all_items() == []
+
+
 def test_integer_dtype_inferred_and_expanded_bounds_stay_integer():
     for dtype in ("i32", "i64"):
         near = RectSprite((1, 1, 2, 2))

--- a/tests/test_python/integration/test_pygame_integration.py
+++ b/tests/test_python/integration/test_pygame_integration.py
@@ -295,54 +295,31 @@ def test_inferred_bounds_growth_set_bounds_rebuild_and_query_rect():
     assert tuple(one_shot) == (0, 0, 10, 10)
 
 
-def test_group_exposes_rect_quadtree_object_api_for_sprites():
+def test_group_exposes_sprite_spatial_query_api():
     near = RectSprite((0, 0, 10, 10), "near")
     mid = RectSprite((40, 40, 10, 10), "mid")
     far = RectSprite((80, 80, 10, 10), "far")
-    missing = RectSprite(label="missing")
 
     group = fpygame.Group(bounds=(0, 0, 100, 100))
-    near_id = group.insert(near)
-    group.add(mid, far)
+    group.add(near, mid, far)
 
-    with pytest.raises(ValueError, match=r"usable pygame\.Rect"):
-        group.insert(missing)
-
-    broken_lookup = fpygame.Group(bounds=(0, 0, 10, 10))
-    broken_lookup._find_sprite_id = lambda sprite, rect_bounds: None
-    with pytest.raises(RuntimeError, match="not found in the quadtree index"):
-        broken_lookup.insert(RectSprite((1, 1, 2, 2)))
-
-    assert group.get(near_id) is near
-    assert group.get(9999) is None
-    assert fpygame.Group().get(near_id) is None
-
-    queried_items = group.query(pygame.Rect(0, 0, 15, 15))
-    assert [item.obj for item in queried_items] == [near]
-    assert group.query_ids((0, 0, 15, 15), sync=False) == [near_id]
+    assert group.query(pygame.Rect(0, 0, 15, 15)) == [near]
     assert group.query(object()) == []
     assert group.query((500, 500, 510, 510)) == []
     assert fpygame.Group().query((0, 0, 1, 1)) == []
 
-    nearest = group.nearest_neighbor((42, 42))
-    assert nearest is not None
-    assert nearest.obj is mid
-    assert [item.obj for item in group.nearest_neighbors((0, 0), 2)] == [near, mid]
+    assert group.nearest_neighbor((42, 42)) is mid
+    assert group.nearest_neighbors((0, 0), 2) == [near, mid]
 
     mid.rect.update(2, 2, 10, 10)
-    assert group.nearest_neighbor((11, 11), sync=True).obj is mid
-    assert [item.obj for item in group.nearest_neighbors((0, 0), 0)] == []
+    assert group.nearest_neighbor((11, 11), sync=True) is mid
+    assert group.nearest_neighbors((0, 0), 0) == []
 
     indexed_empty = fpygame.Group(bounds=(0, 0, 10, 10))
     assert indexed_empty.nearest_neighbor((0, 0)) is None
     assert indexed_empty.nearest_neighbors((0, 0), 1) == []
     assert fpygame.Group().nearest_neighbors((0, 0), 1) == []
     assert fpygame.Group().nearest_neighbors((0, 0), 1, sync=False) == []
-
-    all_items = group.get_all_items()
-    assert {item.obj for item in all_items} == {near, mid, far}
-    assert set(group.get_all_objects()) == {near, mid, far}
-    assert fpygame.Group().get_all_items() == []
 
 
 def test_integer_dtype_inferred_and_expanded_bounds_stay_integer():
@@ -592,17 +569,16 @@ def test_internal_edge_paths_keep_public_behavior_stable():
     group._index_sprite(sprite)
     assert group.indexed_count == 1
     group._tree = None
-    assert group._find_sprite_id(sprite, (1, 1, 6, 6)) is None
     group._ensure_tree_contains((1, 1, 6, 6))
     assert group._tree is not None
-
-    other = RectSprite((1, 1, 5, 5))
-    assert group._find_sprite_id(other, (1, 1, 6, 6)) is None
 
     first_same_rect = RectSprite((4, 4, 6, 6))
     second_same_rect = RectSprite((4, 4, 6, 6))
     same_rect_group = fpygame.Group((0, 0, 20, 20), first_same_rect, second_same_rect)
-    assert same_rect_group._find_sprite_id(second_same_rect, (4, 4, 10, 10)) is not None
+    assert set(same_rect_group.query_rect((4, 4, 10, 10))) == {
+        first_same_rect,
+        second_same_rect,
+    }
 
     nested_group = pygame.sprite.Group(sprite)
     inferred_from_group = fpygame.Group(nested_group)

--- a/tests/test_python/integration/test_pygame_integration.py
+++ b/tests/test_python/integration/test_pygame_integration.py
@@ -327,7 +327,7 @@ def test_query_rect_warns_for_3_0_deprecation():
     group = fpygame.Group(bounds=(0, 0, 100, 100))
     group.add(sprite)
 
-    with pytest.warns(DeprecationWarning, match="removed in fastquadtree 3.0"):
+    with pytest.warns(DeprecationWarning, match="breaking API cleanup"):
         assert group.query_rect(sprite.rect) == [sprite]
 
 

--- a/tests/test_python/integration/test_pygame_integration.py
+++ b/tests/test_python/integration/test_pygame_integration.py
@@ -220,7 +220,7 @@ def test_sync_ignores_sprites_that_are_not_group_members():
 
     assert external not in group
     assert group.indexed_count == 1
-    assert group.query_rect(query.rect, sync=False) == [member]
+    assert group.query(query.rect, sync=False) == [member]
     assert fpygame.spritecollide(query, group, False, sync=False) == [member]
 
 
@@ -248,31 +248,31 @@ def test_rebuild_on_update_reindexes_all_moved_sprites():
     assert group.copy()._rebuild_on_update is True
 
 
-def test_inferred_bounds_growth_set_bounds_rebuild_and_query_rect():
+def test_inferred_bounds_growth_set_bounds_rebuild_and_query():
     near = RectSprite((0, 0, 10, 10))
     far = RectSprite((500, 500, 10, 10))
     group = fpygame.Group([near])
 
     assert group.bounds is not None
-    assert group.query_rect((0, 0, 10, 10)) == [near]
+    assert group.query((0, 0, 10, 10)) == [near]
 
     group.add(far)
     assert group.bounds is not None
     assert group.bounds[2] > 500
-    assert group.query_rect(far.rect) == [far]
+    assert group.query(far.rect) == [far]
 
     group.set_bounds((-1000, -1000, 1000, 1000))
     assert group.bounds == (-1000, -1000, 1000, 1000)
     assert group.indexed_count == 2
 
     group.rebuild()
-    assert set(group.query_rect(pygame.Rect(-1, -1, 20, 20))) == {near}
-    assert group.query_rect((0, 0, 0, 10)) == []
+    assert set(group.query(pygame.Rect(-1, -1, 20, 20))) == {near}
+    assert group.query((0, 0, 0, 10)) == []
 
     fixed_bounds = group.bounds
-    assert group.query_rect((5000, 5000, 5010, 5010)) == []
+    assert group.query((5000, 5000, 5010, 5010)) == []
     assert group.bounds == fixed_bounds
-    assert set(group.query_rect((-2000, -2000, 5, 5))) == {near}
+    assert set(group.query((-2000, -2000, 5, 5))) == {near}
     assert group.bounds == fixed_bounds
 
     generator_sprites = [RectSprite((1, 1, 4, 4)), RectSprite((20, 20, 4, 4))]
@@ -322,6 +322,15 @@ def test_group_exposes_sprite_spatial_query_api():
     assert fpygame.Group().nearest_neighbors((0, 0), 1, sync=False) == []
 
 
+def test_query_rect_warns_for_3_0_deprecation():
+    sprite = RectSprite((0, 0, 10, 10))
+    group = fpygame.Group(bounds=(0, 0, 100, 100))
+    group.add(sprite)
+
+    with pytest.warns(DeprecationWarning, match="removed in fastquadtree 3.0"):
+        assert group.query_rect(sprite.rect) == [sprite]
+
+
 def test_integer_dtype_inferred_and_expanded_bounds_stay_integer():
     for dtype in ("i32", "i64"):
         near = RectSprite((1, 1, 2, 2))
@@ -330,7 +339,7 @@ def test_integer_dtype_inferred_and_expanded_bounds_stay_integer():
         inferred = fpygame.Group([near], dtype=dtype)
         assert inferred.bounds is not None
         assert all(isinstance(value, int) for value in inferred.bounds)
-        assert inferred.query_rect(near.rect) == [near]
+        assert inferred.query(near.rect) == [near]
 
         empty = fpygame.Group(dtype=dtype)
         empty.rebuild()
@@ -340,7 +349,7 @@ def test_integer_dtype_inferred_and_expanded_bounds_stay_integer():
         expanded.add(far)
         assert expanded.bounds is not None
         assert all(isinstance(value, int) for value in expanded.bounds)
-        assert expanded.query_rect(far.rect) == [far]
+        assert expanded.query(far.rect) == [far]
 
 
 def test_bulk_add_batches_index_rebuilds():
@@ -373,9 +382,7 @@ def test_bulk_add_batches_index_rebuilds():
     outside_group.add(outside)
     assert outside_rebuilds == 1
     assert outside_group.indexed_count == 2
-    assert set(outside_group.query_rect((190, 190, 410, 410), sync=False)) == set(
-        outside
-    )
+    assert set(outside_group.query((190, 190, 410, 410), sync=False)) == set(outside)
 
 
 def test_unusable_rects_preserve_pygame_fallback_behavior():
@@ -484,7 +491,7 @@ def test_invalid_constructor_and_query_inputs_are_handled():
     group = fpygame.Group()
     assert group.bounds is None
     assert group.indexed_count == 0
-    assert group.query_rect(object()) == []
+    assert group.query(object()) == []
 
 
 def test_internal_edge_paths_keep_public_behavior_stable():
@@ -514,16 +521,16 @@ def test_internal_edge_paths_keep_public_behavior_stable():
     rect_bounds_group.set_bounds(pygame.Rect(-10, -10, 20, 20), rebuild=False)
     assert rect_bounds_group.bounds == (-10, -10, 10, 10)
 
-    assert fpygame.Group().query_rect(pygame.Rect(0, 0, 1, 1)) == []
-    assert no_rebuild.query_rect(sprite.rect, sync=False) == [sprite]
+    assert fpygame.Group().query(pygame.Rect(0, 0, 1, 1)) == []
+    assert no_rebuild.query(sprite.rect, sync=False) == [sprite]
 
     no_rebuild._tree.insert((50, 50, 51, 51), obj=None)
-    assert no_rebuild.query_rect((50, 50, 51, 51), sync=False) == []
+    assert no_rebuild.query((50, 50, 51, 51), sync=False) == []
 
     no_rebuild._tree.clear()
     sprite.rect.move_ip(1, 1)
     no_rebuild.sync(sprite)
-    assert no_rebuild.query_rect(sprite.rect) == [sprite]
+    assert no_rebuild.query(sprite.rect) == [sprite]
 
     no_rebuild.add(sprite)
     assert no_rebuild.indexed_count == 1
@@ -539,20 +546,20 @@ def test_internal_edge_paths_keep_public_behavior_stable():
     outside_group = fpygame.Group((0, 0, 10, 10), outside_sync)
     outside_sync.rect.update(100, 100, 2, 2)
     outside_group.sync(outside_sync)
-    assert outside_group.query_rect(outside_sync.rect) == [outside_sync]
+    assert outside_group.query(outside_sync.rect) == [outside_sync]
 
     batch_update = RectSprite((10, 10, 2, 2))
     batch_group = fpygame.Group((0, 0, 100, 100), batch_update)
     batch_update.rect.move_ip(1, 1)
     batch_group.add(batch_update)
-    assert batch_group.query_rect(batch_update.rect, sync=False) == [batch_update]
+    assert batch_group.query(batch_update.rect, sync=False) == [batch_update]
 
     stale_batch = RectSprite((20, 20, 2, 2))
     stale_batch_group = fpygame.Group((0, 0, 100, 100), stale_batch)
     stale_batch.rect.move_ip(1, 1)
     stale_batch_group._tree.clear()
     stale_batch_group.add(stale_batch)
-    assert stale_batch_group.query_rect(stale_batch.rect, sync=False) == [stale_batch]
+    assert stale_batch_group.query(stale_batch.rect, sync=False) == [stale_batch]
 
     stale = fpygame.Group((0, 0, 10, 10), sprite)
     stale._tree.clear()
@@ -575,7 +582,7 @@ def test_internal_edge_paths_keep_public_behavior_stable():
     first_same_rect = RectSprite((4, 4, 6, 6))
     second_same_rect = RectSprite((4, 4, 6, 6))
     same_rect_group = fpygame.Group((0, 0, 20, 20), first_same_rect, second_same_rect)
-    assert set(same_rect_group.query_rect((4, 4, 10, 10))) == {
+    assert set(same_rect_group.query((4, 4, 10, 10))) == {
         first_same_rect,
         second_same_rect,
     }

--- a/tests/test_python/rects/test_rect_quadtree_core.py
+++ b/tests/test_python/rects/test_rect_quadtree_core.py
@@ -156,9 +156,9 @@ def test_contains_robust(bounds, dtype):
     if dtype.startswith("i"):
         exact_int_rect = (25, 35, 45, 55)
         rqt.insert(exact_int_rect)
-        assert (
-            exact_int_rect in rqt
-        ), "Integer rectangle should be found with exact match"
+        assert exact_int_rect in rqt, (
+            "Integer rectangle should be found with exact match"
+        )
         # Off-by-one should not match
         assert (25, 35, 45, 56) not in rqt, "Off-by-one rectangle should not match"
         assert (26, 35, 45, 55) not in rqt, "Off-by-one rectangle should not match"

--- a/tests/test_python/rects_objects/test_rect_quadtree_objects_core.py
+++ b/tests/test_python/rects_objects/test_rect_quadtree_objects_core.py
@@ -115,9 +115,9 @@ def test_contains_robust(bounds, dtype):
     if dtype.startswith("i"):
         exact_int_rect = (25, 35, 45, 55)
         rqt.insert(exact_int_rect)
-        assert (
-            exact_int_rect in rqt
-        ), "Integer rectangle should be found with exact match"
+        assert exact_int_rect in rqt, (
+            "Integer rectangle should be found with exact match"
+        )
         # Off-by-one should not match
         assert (25, 35, 45, 56) not in rqt, "Off-by-one rectangle should not match"
         assert (26, 35, 45, 55) not in rqt, "Off-by-one rectangle should not match"

--- a/tests/test_python/test_pyqtree_shim_compat.py
+++ b/tests/test_python/test_pyqtree_shim_compat.py
@@ -54,9 +54,9 @@ def results_match_exact(fqt, pyq, query):
     """Compare lists exactly, not just as sets."""
     got_fqt = sorted(fqt.intersect(query))
     got_pyq = sorted(pyq.intersect(query))
-    assert (
-        got_fqt == got_pyq
-    ), f"\nquery={query}\nfastquadtree={got_fqt}\npyqtree={got_pyq}"
+    assert got_fqt == got_pyq, (
+        f"\nquery={query}\nfastquadtree={got_fqt}\npyqtree={got_pyq}"
+    )
 
 
 def test_ctor_error_branch():


### PR DESCRIPTION
## Summary

This is the small 2.4.0 release branch for the pygame integration. It adds sprite-oriented spatial query methods on `fastquadtree.pygame.Group` and updates the docs/examples around the pygame API.

Changes:
- Add `Group.query(...)` for direct rectangle queries that return pygame sprites.
- Keep `Group.query_rect(...)` as a backward-compatible wrapper for 2.3.0 callers, with a `DeprecationWarning` that points users to `Group.query(...)` and notes it would be removed if a future fastquadtree 3.0 does breaking API cleanup.
- Add `Group.nearest_neighbor(...)` and `Group.nearest_neighbors(...)` over indexed sprite rects.
- Update internal pygame collision helpers to call `Group.query(...)` directly so users do not get `query_rect(...)` deprecation warnings through `spritecollide(...)` / `spritecollideany(...)`.
- Update internal pygame index maintenance to use object-based `RectQuadTreeObjects` update/delete helpers instead of exposing or tracking quadtree IDs.
- Update README and docs to describe sprite rect queries and k-NN.
- Minor formatting changes due to updating from Ruff 0.6 to 0.15 in the pre-commit hooks
- Bump version metadata from `2.3.0` to `2.4.0`.

## Compatibility / reviewer notes

I compared this branch to `main` for public breaking changes. I did not find public API removals:
- `fastquadtree.pygame.__all__` is unchanged.
- `Group.query_rect(...)` remains available and delegates to `Group.query(...)`, but direct calls now emit a `DeprecationWarning`.
- The new methods are additive.
- In the project pygame-ce environment, `pygame.sprite.Group` does not define `query`, `query_rect`, `nearest_neighbor`, or `nearest_neighbors`, so the additions do not shadow existing pygame group methods.

There are no current plans for a 3.0 release; the warning only identifies a future breaking-release cleanup point if one happens.

One private helper, `Group._find_sprite_id`, was removed as part of the internals cleanup. That is not public API, but downstream code reaching into internals would need to stop using it.

## Verification

- `.venv/bin/python -m pytest --no-cov tests/test_python/integration/test_pygame_integration.py tests/test_python/integration/test_public_api_contracts.py` - 25 passed
- `.venv/bin/python -m pytest --no-cov tests/test_python/integration/test_pygame_integration.py` - 20 passed after adding the deprecation warning
- `.venv/bin/python -m pytest --no-cov tests/test_python` - 355 passed
- `cargo test` - passed before the deprecation-only Python/doc update
